### PR TITLE
Add basic travis-ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: minimal
+
+services:
+  - docker
+
+jobs:
+  include:
+    - script: |
+        docker run -it -v ${TRAVIS_BUILD_DIR}:/repo.git -w /repo.git chapel/chapel:1.20.0 /bin/bash -c '
+        apt-get update && apt-get install -y libhdf5-dev libzmq3-dev python3-pip &&
+        pip3 install --user pyzmq numpy &&
+        echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths &&
+        ARKOUDA_DEVELOPER=true make &&
+        { ./arkouda_server &>server.log & } && PYTHONPATH=$PWD:$PYTHONPATH ./tests/check.py'

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ VERBOSE ?= 0
 
 CHPL := chpl
 CHPL_DEBUG_FLAGS += --print-passes
+ifndef ARKOUDA_DEVELOPER
 CHPL_FLAGS += --fast
+endif
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
 # --cache-remote does not work with ugni in Chapel 1.20

--- a/tests/check.py
+++ b/tests/check.py
@@ -17,10 +17,13 @@ else:
     ak.connect()
 
 
-N = 1_000_000
+N = 1000000
 
 
+errors = False
 def pass_fail(f):
+    global errors
+    errors = errors or not f
     return ("Passed" if f else "Failed")
 
 def check_arange(N):
@@ -257,3 +260,4 @@ print("check set integer idx = value:", check_set_integer_idx(N))
 
 #ak.disconnect()
 ak.shutdown()
+sys.exit(errors)


### PR DESCRIPTION
Run tests/checks.py with a comm=none server build.

This uses the Chapel 1.20 comm=none docker image. The script installs
the dependencies (hdf5, zmq, python3 and python deps.) hdf5 is not
installed to a "normal" location, but is instead installed in a
`hdf5/serial` subdir, so we have to add that to `Makefile.paths` so the
server can find it. The server is built without `--fast` to speed up
backend compilation times and to run with Chapel's checks enabled.
check.py was modified to set an exit code to detect failures and
underscores were removed from numbers since that was only added in
python 3.6 and the travis config is using python 3.5.